### PR TITLE
Rename cmp() method to equals()

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ struct myClass {
     inline void end(const myClass* ref) { pos = ref->vec.size(); }
     inline float& get(myClass* ref) { return ref->vec[pos]; }
     inline const float& get(const myClass* ref) { return ref->vec[pos]; }
-    inline bool cmp(const it_state& s) const { return pos != s.pos; }
+    inline bool equals(const it_state& s) const { return pos == s.pos; }
   };
   SETUP_ITERATORS(myClass, float&, it_state);
 };
@@ -88,7 +88,7 @@ struct myClass {
     inline void end(const myClass* ref) { pos = ref->vec.size(); }
     inline float& get(myClass* ref) { return ref->vec[pos]; }
     inline const float& get(const myClass* ref) { return ref->vec[pos]; }
-    inline bool cmp(const it_state& s) const { return pos != s.pos; }
+    inline bool equals(const it_state& s) const { return pos == s.pos; }
   };
   SETUP_ITERATORS(myClass, float&, it_state);
   SETUP_REVERSE_ITERATORS(myClass, float&, it_state); // <-- Add REVERSE_ITERATORS macro
@@ -149,7 +149,7 @@ would not be possible, e.g.:
     inline void end(const myClass* ref) { pos = ref->vec.size(); }
     inline float get(myClass* ref) { return 1 + ref->vec[pos]; }
     inline const float get(const myClass* ref) { return 1 + ref->vec[pos]; }
-    inline bool cmp(const it_state& s) const { return pos != s.pos; }
+    inline bool equals(const it_state& s) const { return pos == s.pos; }
   };
 ```
 
@@ -170,7 +170,7 @@ struct myClass {
     inline void end(const myClass* ref) { pos = ref->vec.size(); }
     inline float& get(myClass* ref) { return ref->vec[pos]; }
     inline const float& get(const myClass* ref) { return ref->vec[pos]; }
-    inline bool cmp(const it_state& s) const { return pos != s.pos; }
+    inline bool equals(const it_state& s) const { return pos == s.pos; }
   };
   SETUP_ITERATORS(myClass, float&, it_state);
   SETUP_REVERSE_ITERATORS(myClass, float&, it_state); // (Optional)
@@ -213,7 +213,7 @@ struct myClass {
     inline void end(const myClass* ref) { pos = ref->vec.size(); }
     inline float& get(myClass* ref) { return ref->vec[pos]; }
     inline const float& get(const myClass* ref) { return ref->vec[pos]; }
-    inline bool cmp(const it_state& s) const { return pos != s.pos; }
+    inline bool equals(const it_state& s) const { return pos == s.pos; }
   };
 
   // Mutable Iterator:

--- a/iterator_tpl.h
+++ b/iterator_tpl.h
@@ -86,7 +86,7 @@ struct iterator {
   // Returns current `value`
   T get() { return state.get(ref); }
   // Return true if `state != s`:
-  bool cmp(const S& s) const { return state.cmp(s); }
+  bool equals(const S& s) const { return state.equals(s); }
 
   // Optional function for reverse iteration:
   void prev() { state.prev(ref); }
@@ -118,7 +118,7 @@ struct iterator {
   iterator& operator--() { prev(); return *this; }
   iterator operator--(int) { iterator temp(*this); prev(); return temp; }
   bool operator!=(const iterator& other) const {
-    return ref != other.ref || cmp(other.state);
+    return ref != other.ref || !equals(other.state);
   }
   bool operator==(const iterator& other) const {
     return !operator!=(other);
@@ -155,7 +155,7 @@ struct iterator<C,T&,S> {
   // Returns current `value`
   T& get() { return state.get(ref); }
   // Return true if `state != s`:
-  bool cmp(const S& s) const { return state.cmp(s); }
+  bool equals(const S& s) const { return state.equals(s); }
 
   // Optional function for reverse iteration:
   void prev() { state.prev(ref); }
@@ -188,7 +188,7 @@ struct iterator<C,T&,S> {
   iterator& operator--() { prev(); return *this; }
   iterator operator--(int) { iterator temp(*this); prev(); return temp; }
   bool operator!=(const iterator& other) const {
-    return ref != other.ref || cmp(other.state);
+    return ref != other.ref || !equals(other.state);
   }
   bool operator==(const iterator& other) const {
     return !operator!=(other);
@@ -230,7 +230,7 @@ struct const_iterator {
   // Returns current `value`
   const T get() { return state.get(ref); }
   // Return true if `state != s`:
-  bool cmp(const S& s) const { return state.cmp(s); }
+  bool equals(const S& s) const { return state.equals(s); }
 
   // Optional function for reverse iteration:
   void prev() { state.prev(ref); }
@@ -267,7 +267,7 @@ struct const_iterator {
   const_iterator& operator--() { prev(); return *this; }
   const_iterator operator--(int) { const_iterator temp(*this); prev(); return temp;  }
   bool operator!=(const const_iterator& other) const {
-    return ref != other.ref || cmp(other.state);
+    return ref != other.ref || !equals(other.state);
   }
   bool operator==(const const_iterator& other) const {
     return !operator!=(other);
@@ -282,7 +282,7 @@ struct const_iterator {
 
   // Comparisons between const and normal iterators:
   bool operator!=(const iterator<C,T,S>& other) const {
-    return ref != other.ref || cmp(other.state);
+    return ref != other.ref || !equals(other.state);
   }
   bool operator==(const iterator<C,T,S>& other) const {
     return !operator!=(other);
@@ -309,7 +309,7 @@ struct const_iterator<C,T&,S> {
   // Returns current `value`
   const T& get() { return state.get(ref); }
   // Return true if `state != s`:
-  bool cmp(const S& s) const { return state.cmp(s); }
+  bool equals(const S& s) const { return state.equals(s); }
 
   // Optional function for reverse iteration:
   void prev() { state.prev(ref); }
@@ -347,7 +347,7 @@ struct const_iterator<C,T&,S> {
   const_iterator& operator--() { prev(); return *this; }
   const_iterator operator--(int) { const_iterator temp(*this); prev(); return temp; }
   bool operator!=(const const_iterator& other) const {
-    return ref != other.ref || cmp(other.state);
+    return ref != other.ref || !equals(other.state);
   }
   bool operator==(const const_iterator& other) const {
     return !operator!=(other);
@@ -362,7 +362,7 @@ struct const_iterator<C,T&,S> {
 
   // Comparisons between const and normal iterators:
   bool operator!=(const iterator<C,T&,S>& other) const {
-    return ref != other.ref || cmp(other.state);
+    return ref != other.ref || !equals(other.state);
   }
   bool operator==(const iterator<C,T&,S>& other) const {
     return !operator!=(other);

--- a/tests.cpp
+++ b/tests.cpp
@@ -19,7 +19,7 @@ struct myClass {
     inline void end(const myClass* ref) { pos = ref->vec.size(); }
     inline float& get(myClass* ref) { return ref->vec[pos]; }
     inline const float& get(const myClass* ref) const { return ref->vec[pos]; }
-    inline bool cmp(const it_state& s) const { return pos != s.pos; }
+    inline bool equals(const it_state& s) const { return pos == s.pos; }
   };
   SETUP_ITERATORS(myClass, float&, it_state);
   SETUP_REVERSE_ITERATORS(myClass, float&, it_state);
@@ -38,7 +38,7 @@ struct myClass_rvalue {
     inline void end(const myClass_rvalue* ref) { pos = ref->vec.size(); }
     inline float get(myClass_rvalue* ref) { return ref->vec[pos] - 1; }
     inline const float get(const myClass_rvalue* ref) { return ref->vec[pos] - 1; }
-    inline bool cmp(const it_state& s) const { return pos != s.pos; }
+    inline bool equals(const it_state& s) const { return pos == s.pos; }
   };
   SETUP_ITERATORS(myClass_rvalue, float, it_state);
   SETUP_REVERSE_ITERATORS(myClass_rvalue, float, it_state);


### PR DESCRIPTION
@heyx3, you'll notice I've inverted the semantics, before it was a "not_equals" operation, now the name is "equals" so I inverted all the boolean comparisons on the examples and on the template to fix this new meaning.