### PR TITLE
Update iterator_tpl.h

### DIFF
--- a/iterator_tpl.h
+++ b/iterator_tpl.h
@@ -188,7 +188,7 @@ struct iterator {
 
   // Comparisons between const and normal iterators:
   bool operator!=(const const_iterator<C,T,S>& other) const {
-    return ref != other.ref || cmd(other.state);
+    return ref != other.ref || !equals(other.state);
   }
   bool operator==(const const_iterator<C,T,S>& other) const {
     return !operator!=(other);
@@ -258,7 +258,7 @@ struct iterator<C,T&,S> {
 
   // Comparisons between const and normal iterators:
   bool operator!=(const const_iterator<C,T&,S>& other) const {
-    return ref != other.ref || cmd(other.state);
+    return ref != other.ref || !equals(other.state);
   }
   bool operator==(const const_iterator<C,T&,S>& other) const {
     return !operator!=(other);


### PR DESCRIPTION
Fix compilation issue introduced during the migration from cmp() to equals()

Fixes issue "Incorrect call to a cmd() function? #16"